### PR TITLE
fixed:An error occurred: Can not convert object to (str) for (filename')

### DIFF
--- a/drilldown.py
+++ b/drilldown.py
@@ -1,13 +1,11 @@
-import os
-
 from pathlib import Path
 
-def drilldown(folder_path, extensions={'.bmp', '.dib', '.jpeg', '.jpg', '.jp2', '.png', '.pbm', '.pgm', '.ppm', '.sr', '.ras', '.tiff', '.tif', '.exr', '.jxr', '.pfm', '.pds', '.pfm', '.viff', '.xbm', '.xpm', '.dds', '.eis', '.mng', '.web', '.hei', '.hei', '.av'}):
-    image_files = []
-    folder_path = Path(folder_path)
+def drilldown(targeted_directory:str, extensions:list[str] = ['.bmp', '.dib', '.jpeg', '.jpg', '.jp2', '.png', '.pbm', '.pgm', '.ppm', '.sr', '.ras', '.tiff', '.tif', '.exr', '.jxr', '.pfm', '.pds', '.pfm', '.viff', '.xbm', '.xpm', '.dds', '.eis', '.mng', '.web', '.hei', '.hei', '.av']):
+    image_files:list[str]= []
+    folder_path:Path = Path(targeted_directory)
     
     for file_path in folder_path.glob('**/*'):
         if file_path.is_file() and file_path.suffix.lower() in extensions:
-            image_files.append(file_path)
-    
+            raw_filename = u'{}'.format(file_path)
+            image_files.append(raw_filename)
     return image_files

--- a/main.py
+++ b/main.py
@@ -1,10 +1,11 @@
 import drilldown
 import imagedata
+from pprint import pprint 
 
 if __name__ == "__main__":
     folder = input('Provide the folder path: ') # Getting the path of the folder to drill down into
     images = drilldown.drilldown(folder) # Getting the list of images in the folder and all sub-folders
-    print('images: ', images)
+    pprint(f"images: {[str(path_object) for path_object in images]}") # more readable than the simple print 
     metadata = []
     i = 0 # testing
     size = images.__len__() # testing
@@ -12,5 +13,4 @@ if __name__ == "__main__":
         print(str(i), '\\', size) #testing
         i+=1 #testing
         metadata.append(imagedata.get_image_metadata(image)) # Fetching metadata for each image for later comparisons
-
-    print("meta: ", metadata)
+    _ =[pprint(data) for data in metadata ] #print each dictionnary seperately


### PR DESCRIPTION
Since I had replaced OS with pathlib
the drilldown module was now returning a list of path objects instead of a list of strings which caused an error with the imread function of cv2 so I modified the driilldown function so that
 it now returns a list of strings while keeping pathlib.
 I have also replaced the print by pprint which i thinks is more readable
 cause its printing elements as list in the termainal.